### PR TITLE
Updated up to GHC 8.6.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ dist
 .tree
 .swp
 .stack-work
+
+*.qmlc
+*.lock

--- a/Andromeda.cabal
+++ b/Andromeda.cabal
@@ -70,6 +70,7 @@ library
     , Andromeda.Utils.DebugPrint
 
     , Andromeda.Assets.SpaceshipSample
+    , Andromeda.Common.Exists
 
   build-depends:       base >= 4.7 && < 5,
                        vector,
@@ -134,6 +135,7 @@ test-suite Andromeda-test
     , Test.Simulator.SimulationSpec
     , Test.Simulator.ControllerScriptRunSpec
     , Test.UI.GraphTransitionSpec
+    , Test.Utils.Untag
 
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010

--- a/src/Andromeda/Types/Language/Hardware/HDL.hs
+++ b/src/Andromeda/Types/Language/Hardware/HDL.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstrainedClassMethods #-}
 {-# LANGUAGE DeriveFunctor #-}
 module Andromeda.Types.Language.Hardware.HDL where
 

--- a/src/Andromeda/Types/Language/Hardware/HNDL.hs
+++ b/src/Andromeda/Types/Language/Hardware/HNDL.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstrainedClassMethods #-}
 {-# LANGUAGE DeriveFunctor #-}
 module Andromeda.Types.Language.Hardware.HNDL where
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,13 +2,13 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration/
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.5
+resolver: lts-14.4
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: [arrows-0.4.4.1, Stream-0.4.7.2, lazysmallcheck-0.6, clock-0.7.2, hsqml-0.3.4.0]
+extra-deps: [arrows-0.4.4.2, Stream-0.4.7.2, lazysmallcheck-0.6, clock-0.7.2, hsqml-0.3.5.1, containers-0.5.11.0, binary-0.8.8.0, text-1.2.4.1, Cabal-2.0.1.1]
 
 # Override default flag values for local packages and extra-deps
 flags: {}
@@ -28,8 +28,8 @@ extra-package-dbs: []
 # arch: x86_64
 
 # Extra directories used by stack for building
-extra-include-dirs: [/opt/Qt/5.1.1/gcc_64/include]
-extra-lib-dirs: [/opt/Qt/5.1.1/gcc_64/lib]
+#extra-include-dirs: [/opt/Qt/5.1.1/gcc_64/include]
+#extra-lib-dirs: [/opt/Qt/5.1.1/gcc_64/lib]
 
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor


### PR DESCRIPTION
I tried update to GHC-8.6.5

Removed  the dependence to custom Qt5.1.1 and added dependence to system Qt5 from Debian repositories
For building on Debian you should install Qt5 qtdeclarative5-dev and qtbase5-dev packages over
`apt install qtdeclarative5-dev and qtbase5-dev`

And I added {-# LANGUAGE ConstrainedClassMethods #-} into src/Andromeda/Types/Language/Hardware/HDL.hs and src/Andromeda/Types/Language/Hardware/HNDL.hs files/


I hope it's work as original version